### PR TITLE
Update Dynamo CRDs helm install flag and fix serviceaccount command

### DIFF
--- a/inference/a3ultra/disaggregated-serving/dynamo/README.md
+++ b/inference/a3ultra/disaggregated-serving/dynamo/README.md
@@ -136,7 +136,7 @@ Install the Dynamo CRDs:
 helm install dynamo-crds dynamo-crds-${RELEASE_VERSION}.tgz \
   --namespace default \
   --wait \
-  --atomic
+  --rollback-on-failure
 ```
 
 Install the Dynamo Platform:

--- a/inference/a4x/disaggregated-serving/dynamo/README.md
+++ b/inference/a4x/disaggregated-serving/dynamo/README.md
@@ -135,7 +135,7 @@ Install the Dynamo CRDs:
 helm install dynamo-crds dynamo-crds-${RELEASE_VERSION}.tgz \
   --namespace default \
   --wait \
-  --atomic
+  --rollback-on-failure
 ```
 
 Install the Dynamo Platform with Grove & Kai scheduler enabled:
@@ -158,7 +158,7 @@ It is recommended to utilize [gcsfuse](https://docs.cloud.google.com/kubernetes-
 
 Find the service account (usually annotated to default):
 ```bash
-kubectl get serviceaccounts ${NAMESPACE} -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.metadata.annotations.iam\.gke\.io/gcp-service-account}{"\n"}{end}'
+kubectl get serviceaccounts -n ${NAMESPACE} -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.metadata.annotations.iam\.gke\.io/gcp-service-account}{"\n"}{end}'
 ```
 
 Config the service account email:


### PR DESCRIPTION
This PR updates the Helm installation commands for Dynamo CRDs in the READMEs to use `--rollback-on-failure` instead of `--atomic`, and fixes a `kubectl` command that was missing the `-n` flag for listing service accounts.

Changes:
- `inference/a4x/disaggregated-serving/dynamo/README.md`:
  - Update `--atomic` to `--rollback-on-failure`
  - Fix `kubectl get serviceaccounts` command to include `-n ${NAMESPACE}` instead of passing `${NAMESPACE}` as a positional argument.
- `inference/a3ultra/disaggregated-serving/dynamo/README.md`:
  - Update `--atomic` to `--rollback-on-failure`

The change from `--atomic` to `--rollback-on-failure` is made because `--atomic` is being deprecated in favor of `--rollback-on-failure` in newer Helm conventions (such as Helm 4). `--rollback-on-failure` explicitly conveys the intent to roll back changes on failure and is the preferred modern flag for this behavior.

These updates ensure consistent and preferred rollback behavior during CRD installation failures, and fix a broken troubleshooting command.