### PR TITLE
Add multi-host sglang serving recipe for Kimi-K3

### DIFF
--- a/inference/a4x/multi-host-serving/sglang/README.md
+++ b/inference/a4x/multi-host-serving/sglang/README.md
@@ -7,6 +7,8 @@ This recipe provides instructions and templates for serving Moonshot AI's **Kimi
 * [1. Test Environment](#test-environment)
 * [2. High-Level Architecture](#architecture)
 * [3. Environment Setup](#environment-setup)
+  * [3.1. Configure Environment Variables](#configure-vars)
+  * [3.2. Pre-upload Model Weights to GCS](#preupload-weights)
 * [4. Deployment Instructions](#deployment-instructions)
 * [5. Inference Requests & Benchmarking](#inference-requests)
 * [6. Cleanup](#cleanup)
@@ -43,6 +45,9 @@ The deployment utilizes `LeaderWorkerSet` (LWS) with a 4-node pod group. A Kuber
 <a name="environment-setup"></a>
 ## 3. Environment Setup
 
+<a name="configure-vars"></a>
+### 3.1. Configure Environment Variables
+
 Configure your cluster and deployment environment variables:
 
 ```bash
@@ -54,6 +59,23 @@ export RELEASE_NAME="sglang-kimi-k3"
 export K8S_SERVICE_ACCOUNT="workload-identity-k8s-sa"
 
 gcloud container clusters get-credentials ${CLUSTER_NAME} --region ${REGION}
+```
+
+<a name="preupload-weights"></a>
+### 3.2. Pre-upload Model Weights to GCS
+
+To avoid downloading large model weights at pod startup, pre-upload the Kimi-K3 Hugging Face checkpoint to your Cloud Storage bucket under `/huggingface_model_cache/models--moonshotai--Kimi-K3`:
+
+```bash
+# 1. Install Hugging Face CLI and high-speed transfer library
+pip install -U "huggingface_hub[cli]" hf_transfer
+
+# 2. Download the Kimi-K3 model checkpoint locally
+export HF_HUB_ENABLE_HF_TRANSFER=1
+huggingface-cli download moonshotai/Kimi-K3 --local-dir ./models--moonshotai--Kimi-K3
+
+# 3. Upload the checkpoint directory to your Cloud Storage bucket
+gcloud storage cp -r ./models--moonshotai--Kimi-K3 gs://${GCS_BUCKET}/huggingface_model_cache/
 ```
 
 <a name="deployment-instructions"></a>

--- a/inference/a4x/multi-host-serving/sglang/README.md
+++ b/inference/a4x/multi-host-serving/sglang/README.md
@@ -1,0 +1,119 @@
+# Multi-Host Inference of Kimi-K3 with SGLang on A4X GKE Node Pool
+
+This recipe provides instructions and templates for serving Moonshot AI's **Kimi-K3** (2.8T parameter hybrid MoE vision-language model) using multi-host [SGLang](https://github.com/sgl-project/sglang) across 4 A4X nodes (16 GPUs) on [Google Kubernetes Engine (GKE)](https://cloud.google.com/kubernetes-engine).
+
+## Table of Contents
+
+* [1. Test Environment](#test-environment)
+* [2. High-Level Architecture](#architecture)
+* [3. Environment Setup](#environment-setup)
+* [4. Deployment Instructions](#deployment-instructions)
+* [5. Inference Requests & Benchmarking](#inference-requests)
+* [6. Cleanup](#cleanup)
+
+<a name="test-environment"></a>
+## 1. Test Environment
+
+* **Orchestration**: Google Kubernetes Engine (GKE)
+* **Compute**: 4 × `a4x-highgpu-4g` nodes (16 NVIDIA GB200 GPUs total)
+* **Serving Engine**: `lmsysorg/sglang:kimi-k3`
+* **Inter-Node Interconnect**: NVIDIA Multi-Node NVLink (MNNVL / NVL72) via `resource.nvidia.com/v1beta1` `ComputeDomain` DRA resource claim
+* **Parallelism Strategy**: Tensor Parallelism (`TP=16`), Decode Context Parallelism (`DCP=16`), Mamba State Ratio `0.86`, Extra Slots `16`
+
+<a name="architecture"></a>
+## 2. High-Level Architecture
+
+The deployment utilizes `LeaderWorkerSet` (LWS) with a 4-node pod group. A Kubernetes `ComputeDomain` resource (`resource.nvidia.com/v1beta1`) binds all 4 nodes into a single NVL72 clique for low-latency NVLink communication across nodes.
+
+```
++-------------------------------------------------------------------------------+
+|                           ComputeDomain (NVL72)                               |
+|                                                                               |
+|  +---------------------+   +---------------------+   +---------------------+  |
+|  | Leader Pod (Rank 0) |---| Worker Pod (Rank 1) |---| Worker Pod (Rank 2) |  |
+|  | 4 × GB200 GPUs      |   | 4 × GB200 GPUs      |   | 4 × GB200 GPUs      |  |
+|  +---------------------+   +---------------------+   +---------------------+  |
+|             \                                                   /             |
+|              +-----------------+ Worker Pod (Rank 3) +---------+              |
+|                                | 4 × GB200 GPUs      |                        |
+|                                +---------------------+                        |
++-------------------------------------------------------------------------------+
+```
+
+<a name="environment-setup"></a>
+## 3. Environment Setup
+
+Ensure your GKE cluster is connected and your environment variables are exported:
+
+```bash
+export CLUSTER_NAME="a4x-baker"
+export REGION="us-central1"
+export NAMESPACE="default"
+
+gcloud container clusters get-credentials ${CLUSTER_NAME} --region ${REGION}
+```
+
+<a name="deployment-instructions"></a>
+## 4. Deployment Instructions
+
+Deploy the LeaderWorkerSet Helm chart for Kimi-K3:
+
+```bash
+cd inference/a4x/multi-host-serving/sglang
+
+helm install -f values_kimi_k3.yaml \
+  --namespace ${NAMESPACE} \
+  pirillo-sglang-kimi-k3 \
+  ../../../../src/helm-charts/a4x/inference-templates/lws-deployment
+```
+
+Monitor pod status:
+
+```bash
+kubectl get pods -n ${NAMESPACE} -l leaderworkerset.sigs.k8s.io/name=pirillo-sglang-kimi-k3 -o wide
+```
+
+<a name="inference-requests"></a>
+## 5. Inference Requests & Benchmarking
+
+### 5.1. OpenAI-Compatible Chat Completion API (Vision & Text)
+
+```bash
+curl http://pirillo-sglang-kimi-k3-svc.default.svc.cluster.local:30100/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "moonshotai/Kimi-K3",
+    "messages": [
+      {
+        "role": "user",
+        "content": [
+          {"type": "text", "text": "Describe this image in detail."},
+          {"type": "image_url", "image_url": {"url": "https://raw.githubusercontent.com/sgl-project/sglang/main/assets/logo.png"}}
+        ]
+      }
+    ]
+  }'
+```
+
+### 5.2. Serving Benchmark (8k Input / 1k Output)
+
+Run the SGLang benchmark client against port 30100:
+
+```bash
+python3 -m sglang.bench_serving \
+  --backend sglang \
+  --host pirillo-sglang-kimi-k3-svc \
+  --port 30100 \
+  --dataset-name random \
+  --num-prompts 100 \
+  --random-input-len 8192 \
+  --random-output-len 1024 \
+  --max-concurrency 32
+```
+
+<a name="cleanup"></a>
+## 6. Cleanup
+
+```bash
+helm uninstall pirillo-sglang-kimi-k3 -n ${NAMESPACE}
+```

--- a/inference/a4x/multi-host-serving/sglang/README.md
+++ b/inference/a4x/multi-host-serving/sglang/README.md
@@ -18,7 +18,7 @@ This recipe provides instructions and templates for serving Moonshot AI's **Kimi
 * **Compute**: 4 × `a4x-highgpu-4g` nodes (16 NVIDIA GB200 GPUs total)
 * **Serving Engine**: `lmsysorg/sglang:kimi-k3`
 * **Inter-Node Interconnect**: NVIDIA Multi-Node NVLink (MNNVL / NVL72) via `resource.nvidia.com/v1beta1` `ComputeDomain` DRA resource claim
-* **Parallelism Strategy**: Tensor Parallelism (`TP=16`), Decode Context Parallelism (`DCP=16`), Mamba State Ratio `0.86`, Extra Slots `16`
+* **Parallelism Strategy**: Tensor Parallelism (`TP=16`), Mamba State Ratio `0.86`
 
 <a name="architecture"></a>
 ## 2. High-Level Architecture
@@ -43,12 +43,15 @@ The deployment utilizes `LeaderWorkerSet` (LWS) with a 4-node pod group. A Kuber
 <a name="environment-setup"></a>
 ## 3. Environment Setup
 
-Ensure your GKE cluster is connected and your environment variables are exported:
+Configure your cluster and deployment environment variables:
 
 ```bash
-export CLUSTER_NAME="a4x-baker"
-export REGION="us-central1"
+export CLUSTER_NAME="<YOUR_CLUSTER_NAME>"
+export REGION="<YOUR_CLUSTER_REGION>"
 export NAMESPACE="default"
+export GCS_BUCKET="<YOUR_GCS_BUCKET_NAME>"
+export RELEASE_NAME="sglang-kimi-k3"
+export K8S_SERVICE_ACCOUNT="workload-identity-k8s-sa"
 
 gcloud container clusters get-credentials ${CLUSTER_NAME} --region ${REGION}
 ```
@@ -61,16 +64,18 @@ Deploy the LeaderWorkerSet Helm chart for Kimi-K3:
 ```bash
 cd inference/a4x/multi-host-serving/sglang
 
-helm install -f values_kimi_k3.yaml \
+helm install ${RELEASE_NAME} \
   --namespace ${NAMESPACE} \
-  pirillo-sglang-kimi-k3 \
+  -f values_kimi_k3.yaml \
+  --set volumes.gcsfuse.bucketName=${GCS_BUCKET} \
+  --set workload.serviceAccountName=${K8S_SERVICE_ACCOUNT} \
   ../../../../src/helm-charts/a4x/inference-templates/lws-deployment
 ```
 
 Monitor pod status:
 
 ```bash
-kubectl get pods -n ${NAMESPACE} -l leaderworkerset.sigs.k8s.io/name=pirillo-sglang-kimi-k3 -o wide
+kubectl get pods -n ${NAMESPACE} -l leaderworkerset.sigs.k8s.io/name=${RELEASE_NAME} -o wide
 ```
 
 <a name="inference-requests"></a>
@@ -79,7 +84,7 @@ kubectl get pods -n ${NAMESPACE} -l leaderworkerset.sigs.k8s.io/name=pirillo-sgl
 ### 5.1. OpenAI-Compatible Chat Completion API (Vision & Text)
 
 ```bash
-curl http://pirillo-sglang-kimi-k3-svc.default.svc.cluster.local:30100/v1/chat/completions \
+curl http://${RELEASE_NAME}-svc.${NAMESPACE}.svc.cluster.local:30100/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{
     "model": "moonshotai/Kimi-K3",
@@ -102,7 +107,7 @@ Run the SGLang benchmark client against port 30100:
 ```bash
 python3 -m sglang.bench_serving \
   --backend sglang \
-  --host pirillo-sglang-kimi-k3-svc \
+  --host ${RELEASE_NAME}-svc \
   --port 30100 \
   --dataset-name random \
   --num-prompts 100 \
@@ -115,5 +120,5 @@ python3 -m sglang.bench_serving \
 ## 6. Cleanup
 
 ```bash
-helm uninstall pirillo-sglang-kimi-k3 -n ${NAMESPACE}
+helm uninstall ${RELEASE_NAME} -n ${NAMESPACE}
 ```

--- a/inference/a4x/multi-host-serving/sglang/values_kimi_k3.yaml
+++ b/inference/a4x/multi-host-serving/sglang/values_kimi_k3.yaml
@@ -10,7 +10,7 @@ workload:
     --trust-remote-code \
     --reasoning-parser kimi_k3 \
     --tool-call-parser kimi_k3 \
-    --mamba-full-memory-ratio 0.86 \
+    --mamba-full-memory-ratio 7.21 \
     --mem-fraction-static 0.85
 
 volumes:

--- a/inference/a4x/multi-host-serving/sglang/values_kimi_k3.yaml
+++ b/inference/a4x/multi-host-serving/sglang/values_kimi_k3.yaml
@@ -5,6 +5,12 @@ workload:
   framework: sglang
   nnodes: 4
   tpSize: 16
+  trustRemoteCode: true
+  reasoningParser: kimi_k3
+  toolCallParser: kimi_k3
+  mambaFullMemoryRatio: 0.86
+  memFractionStatic: 0.85
+  extraPipPackages: hf_transfer fla-core
   serviceAccountName: workload-identity-k8s-sa
 
 volumes:

--- a/inference/a4x/multi-host-serving/sglang/values_kimi_k3.yaml
+++ b/inference/a4x/multi-host-serving/sglang/values_kimi_k3.yaml
@@ -1,0 +1,13 @@
+workload:
+  model: moonshotai/Kimi-K3
+  modelPath: gs://pirillo-sct-bucket/huggingface_model_cache/models--moonshotai--Kimi-K3/
+  image: lmsysorg/sglang:kimi-k3
+  framework: sglang
+  nnodes: 4
+  tpSize: 16
+  dcpSize: 16
+  serviceAccountName: workload-identity-k8s-sa
+
+volumes:
+  gcsfuse:
+    bucketName: pirillo-sct-bucket

--- a/inference/a4x/multi-host-serving/sglang/values_kimi_k3.yaml
+++ b/inference/a4x/multi-host-serving/sglang/values_kimi_k3.yaml
@@ -1,13 +1,12 @@
 workload:
   model: moonshotai/Kimi-K3
-  modelPath: gs://pirillo-sct-bucket/huggingface_model_cache/models--moonshotai--Kimi-K3/
+  modelPath: /data/model/huggingface_model_cache/models--moonshotai--Kimi-K3
   image: lmsysorg/sglang:kimi-k3
   framework: sglang
   nnodes: 4
   tpSize: 16
-  dcpSize: 16
   serviceAccountName: workload-identity-k8s-sa
 
 volumes:
   gcsfuse:
-    bucketName: pirillo-sct-bucket
+    bucketName: <YOUR_GCS_BUCKET>

--- a/inference/a4x/multi-host-serving/sglang/values_kimi_k3.yaml
+++ b/inference/a4x/multi-host-serving/sglang/values_kimi_k3.yaml
@@ -5,13 +5,13 @@ workload:
   framework: sglang
   nnodes: 4
   tpSize: 16
-  trustRemoteCode: true
-  reasoningParser: kimi_k3
-  toolCallParser: kimi_k3
-  mambaFullMemoryRatio: 0.86
-  memFractionStatic: 0.85
-  extraPipPackages: hf_transfer fla-core
   serviceAccountName: workload-identity-k8s-sa
+  extraArgs: |
+    --trust-remote-code \
+    --reasoning-parser kimi_k3 \
+    --tool-call-parser kimi_k3 \
+    --mamba-full-memory-ratio 0.86 \
+    --mem-fraction-static 0.85
 
 volumes:
   gcsfuse:

--- a/inference/a4x/multi-host-serving/sglang/values_kimi_k3.yaml
+++ b/inference/a4x/multi-host-serving/sglang/values_kimi_k3.yaml
@@ -11,6 +11,7 @@ workload:
     --reasoning-parser kimi_k3 \
     --tool-call-parser kimi_k3 \
     --mamba-full-memory-ratio 7.21 \
+    --dcp-size 16 \
     --mem-fraction-static 0.85
 
 volumes:

--- a/src/helm-charts/a4x/inference-templates/lws-deployment/Chart.yaml
+++ b/src/helm-charts/a4x/inference-templates/lws-deployment/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: lws-deployment
+description: A Helm chart for multi-host SGLang inference deployment using LeaderWorkerSet on A4X GKE
+type: application
+version: 0.1.0
+appVersion: "1.0.0"

--- a/src/helm-charts/a4x/inference-templates/lws-deployment/templates/lws-compute-domain.yaml
+++ b/src/helm-charts/a4x/inference-templates/lws-deployment/templates/lws-compute-domain.yaml
@@ -1,0 +1,10 @@
+apiVersion: resource.nvidia.com/v1beta1
+kind: ComputeDomain
+metadata:
+  name: {{ .Release.Name }}-compute-domain
+  namespace: default
+spec:
+  numNodes: {{ .Values.workload.nnodes | default 4 }}
+  channel:
+    resourceClaimTemplate:
+      name: {{ .Release.Name }}-compute-domain-claim

--- a/src/helm-charts/a4x/inference-templates/lws-deployment/templates/lws-compute-domain.yaml
+++ b/src/helm-charts/a4x/inference-templates/lws-deployment/templates/lws-compute-domain.yaml
@@ -2,7 +2,7 @@ apiVersion: resource.nvidia.com/v1beta1
 kind: ComputeDomain
 metadata:
   name: {{ .Release.Name }}-compute-domain
-  namespace: default
+  namespace: {{ .Release.Namespace }}
 spec:
   numNodes: {{ .Values.workload.nnodes | default 4 }}
   channel:

--- a/src/helm-charts/a4x/inference-templates/lws-deployment/templates/lws-launcher.yaml
+++ b/src/helm-charts/a4x/inference-templates/lws-deployment/templates/lws-launcher.yaml
@@ -50,7 +50,7 @@ spec:
           csi:
             driver: gcsfuse.csi.storage.gke.io
             volumeAttributes:
-              bucketName: "{{ .Values.volumes.gcsfuse.bucketName | default "pirillo-sct-bucket" }}"
+              bucketName: "{{ .Values.volumes.gcsfuse.bucketName }}"
               mountOptions: "implicit-dirs,file-cache:enable-parallel-downloads:true,file-cache:parallel-downloads-per-file:100,file-cache:max-parallel-downloads:-1,file-cache:download-chunk-size-mb:50,file-cache:max-size-mb:-1"
         - name: shared-memory
           emptyDir:
@@ -145,7 +145,7 @@ spec:
 
             python3 -m sglang.launch_server \
               --trust-remote-code \
-              --model-path {{ .Values.workload.modelPath | default "/data/model/huggingface_model_cache/models--moonshotai--Kimi-K3" }} \
+              --model-path {{ .Values.workload.modelPath | default (printf "/data/model/%s" .Values.workload.model) }} \
               --tp-size {{ .Values.workload.tpSize | default 16 }} \
               --nnodes ${SIZE} \
               --node-rank ${RANK} \
@@ -197,7 +197,7 @@ spec:
           csi:
             driver: gcsfuse.csi.storage.gke.io
             volumeAttributes:
-              bucketName: "{{ .Values.volumes.gcsfuse.bucketName | default "pirillo-sct-bucket" }}"
+              bucketName: "{{ .Values.volumes.gcsfuse.bucketName }}"
               mountOptions: "implicit-dirs,file-cache:enable-parallel-downloads:true,file-cache:parallel-downloads-per-file:100,file-cache:max-parallel-downloads:-1,file-cache:download-chunk-size-mb:50,file-cache:max-size-mb:-1"
         - name: shared-memory
           emptyDir:
@@ -292,7 +292,7 @@ spec:
 
             python3 -m sglang.launch_server \
               --trust-remote-code \
-              --model-path {{ .Values.workload.modelPath | default "/data/model/huggingface_model_cache/models--moonshotai--Kimi-K3" }} \
+              --model-path {{ .Values.workload.modelPath | default (printf "/data/model/%s" .Values.workload.model) }} \
               --tp-size {{ .Values.workload.tpSize | default 16 }} \
               --nnodes ${SIZE} \
               --node-rank ${RANK} \

--- a/src/helm-charts/a4x/inference-templates/lws-deployment/templates/lws-launcher.yaml
+++ b/src/helm-charts/a4x/inference-templates/lws-deployment/templates/lws-launcher.yaml
@@ -127,7 +127,7 @@ spec:
             set -e
             nvidia-smi
             . /usr/local/gib/scripts/set_nccl_env.sh
-            pip install --break-system-packages hf_transfer fla-core google-cloud-storage || true
+            pip install --break-system-packages hf_transfer fla-core || true
 
             MY_IP=$(hostname -I | awk '{print $1}')
             export SGLANG_HOST_IP="${MY_IP}"
@@ -145,18 +145,14 @@ spec:
 
             python3 -m sglang.launch_server \
               --trust-remote-code \
-              --model-path {{ .Values.workload.modelPath | default "gs://pirillo-sct-bucket/huggingface_model_cache/models--moonshotai--Kimi-K3/" }} \
+              --model-path {{ .Values.workload.modelPath | default "/data/model/huggingface_model_cache/models--moonshotai--Kimi-K3" }} \
               --tp-size {{ .Values.workload.tpSize | default 16 }} \
               --nnodes ${SIZE} \
               --node-rank ${RANK} \
               --dist-init-addr ${LEADER_HOST}:20000 \
-              --dcp-size {{ .Values.workload.dcpSize | default 16 }} \
               --mem-fraction-static 0.85 \
-              --disaggregation-decode-extra-slots 16 \
               --reasoning-parser kimi_k3 \
               --tool-call-parser kimi_k3 \
-              --disaggregation-mode decode \
-              --disaggregation-transfer-backend nixl \
               --mamba-full-memory-ratio 0.86 \
               --host 0.0.0.0 \
               --port 30100 2>&1 | tee /gcs-cache/sglang_server_${RANK}.log
@@ -278,7 +274,7 @@ spec:
             set -e
             nvidia-smi
             . /usr/local/gib/scripts/set_nccl_env.sh
-            pip install --break-system-packages hf_transfer fla-core google-cloud-storage || true
+            pip install --break-system-packages hf_transfer fla-core || true
 
             MY_IP=$(hostname -I | awk '{print $1}')
             export SGLANG_HOST_IP="${MY_IP}"
@@ -296,18 +292,14 @@ spec:
 
             python3 -m sglang.launch_server \
               --trust-remote-code \
-              --model-path {{ .Values.workload.modelPath | default "gs://pirillo-sct-bucket/huggingface_model_cache/models--moonshotai--Kimi-K3/" }} \
+              --model-path {{ .Values.workload.modelPath | default "/data/model/huggingface_model_cache/models--moonshotai--Kimi-K3" }} \
               --tp-size {{ .Values.workload.tpSize | default 16 }} \
               --nnodes ${SIZE} \
               --node-rank ${RANK} \
               --dist-init-addr ${LEADER_HOST}:20000 \
-              --dcp-size {{ .Values.workload.dcpSize | default 16 }} \
               --mem-fraction-static 0.85 \
-              --disaggregation-decode-extra-slots 16 \
               --reasoning-parser kimi_k3 \
               --tool-call-parser kimi_k3 \
-              --disaggregation-mode decode \
-              --disaggregation-transfer-backend nixl \
               --mamba-full-memory-ratio 0.86 \
               --host 0.0.0.0 \
               --port 30100 2>&1 | tee /gcs-cache/sglang_server_${RANK}.log

--- a/src/helm-charts/a4x/inference-templates/lws-deployment/templates/lws-launcher.yaml
+++ b/src/helm-charts/a4x/inference-templates/lws-deployment/templates/lws-launcher.yaml
@@ -2,7 +2,7 @@ apiVersion: leaderworkerset.x-k8s.io/v1
 kind: LeaderWorkerSet
 metadata:
   name: {{ .Release.Name }}
-  namespace: default
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ .Release.Name }}
 spec:

--- a/src/helm-charts/a4x/inference-templates/lws-deployment/templates/lws-launcher.yaml
+++ b/src/helm-charts/a4x/inference-templates/lws-deployment/templates/lws-launcher.yaml
@@ -151,24 +151,11 @@ spec:
               --nnodes ${SIZE} \
               --node-rank ${RANK} \
               --dist-init-addr ${LEADER_HOST}:20000 \
-              --mem-fraction-static {{ .Values.workload.memFractionStatic | default 0.85 }} \
-              {{- if .Values.workload.trustRemoteCode }}
-              --trust-remote-code \
-              {{- end }}
-              {{- if .Values.workload.reasoningParser }}
-              --reasoning-parser {{ .Values.workload.reasoningParser }} \
-              {{- end }}
-              {{- if .Values.workload.toolCallParser }}
-              --tool-call-parser {{ .Values.workload.toolCallParser }} \
-              {{- end }}
-              {{- if .Values.workload.mambaFullMemoryRatio }}
-              --mamba-full-memory-ratio {{ .Values.workload.mambaFullMemoryRatio }} \
-              {{- end }}
-              {{- if .Values.workload.extraArgs }}
-              {{ .Values.workload.extraArgs }} \
-              {{- end }}
               --host 0.0.0.0 \
-              --port 30100 2>&1 | tee /gcs-cache/sglang_server_${RANK}.log
+              --port 30100 \
+              {{- if .Values.workload.extraArgs }}
+              {{ .Values.workload.extraArgs | nindent 14 }}
+              {{- end }} 2>&1 | tee /gcs-cache/sglang_server_${RANK}.log
 
     workerTemplate:
       metadata:
@@ -311,21 +298,8 @@ spec:
               --nnodes ${SIZE} \
               --node-rank ${RANK} \
               --dist-init-addr ${LEADER_HOST}:20000 \
-              --mem-fraction-static {{ .Values.workload.memFractionStatic | default 0.85 }} \
-              {{- if .Values.workload.trustRemoteCode }}
-              --trust-remote-code \
-              {{- end }}
-              {{- if .Values.workload.reasoningParser }}
-              --reasoning-parser {{ .Values.workload.reasoningParser }} \
-              {{- end }}
-              {{- if .Values.workload.toolCallParser }}
-              --tool-call-parser {{ .Values.workload.toolCallParser }} \
-              {{- end }}
-              {{- if .Values.workload.mambaFullMemoryRatio }}
-              --mamba-full-memory-ratio {{ .Values.workload.mambaFullMemoryRatio }} \
-              {{- end }}
-              {{- if .Values.workload.extraArgs }}
-              {{ .Values.workload.extraArgs }} \
-              {{- end }}
               --host 0.0.0.0 \
-              --port 30100 2>&1 | tee /gcs-cache/sglang_server_${RANK}.log
+              --port 30100 \
+              {{- if .Values.workload.extraArgs }}
+              {{ .Values.workload.extraArgs | nindent 14 }}
+              {{- end }} 2>&1 | tee /gcs-cache/sglang_server_${RANK}.log

--- a/src/helm-charts/a4x/inference-templates/lws-deployment/templates/lws-launcher.yaml
+++ b/src/helm-charts/a4x/inference-templates/lws-deployment/templates/lws-launcher.yaml
@@ -1,0 +1,313 @@
+apiVersion: leaderworkerset.x-k8s.io/v1
+kind: LeaderWorkerSet
+metadata:
+  name: {{ .Release.Name }}
+  namespace: default
+  labels:
+    app: {{ .Release.Name }}
+spec:
+  replicas: 1
+  leaderWorkerTemplate:
+    size: {{ .Values.workload.nnodes | default 4 }}
+    restartPolicy: RecreateGroupOnPodRestart
+    leaderTemplate:
+      metadata:
+        labels:
+          role: leader
+          app: {{ .Release.Name }}
+        annotations:
+          gke-gcsfuse/volumes: "true"
+          gke-gcsfuse/cpu-limit: "0"
+          gke-gcsfuse/memory-limit: "0"
+          gke-gcsfuse/ephemeral-storage-limit: "0"
+          gke-gcsfuse/file-cache-capacity: "500Gi"
+          gke-gcsfuse/cache-path: "/gcs-cache"
+          networking.gke.io/default-interface: "eth0"
+      spec:
+        hostNetwork: true
+        dnsPolicy: ClusterFirstWithHostNet
+        serviceAccountName: {{ .Values.workload.serviceAccountName | default "workload-identity-k8s-sa" }}
+        automountServiceAccountToken: true
+        subdomain: {{ .Release.Name }}
+        restartPolicy: Always
+        resourceClaims:
+        - name: compute-domain-channel
+          resourceClaimTemplateName: {{ .Release.Name }}-compute-domain-claim
+        tolerations:
+        - key: "kubernetes.io/arch"
+          operator: "Equal"
+          value: "arm64"
+          effect: "NoSchedule"
+        - key: "nvidia.com/gpu"
+          operator: "Exists"
+          effect: "NoSchedule"
+        volumes:
+        - name: gib
+          emptyDir: {}
+        - name: local-ssd
+          emptyDir: {}
+        - name: gcs-model-volume
+          csi:
+            driver: gcsfuse.csi.storage.gke.io
+            volumeAttributes:
+              bucketName: "{{ .Values.volumes.gcsfuse.bucketName | default "pirillo-sct-bucket" }}"
+              mountOptions: "implicit-dirs,file-cache:enable-parallel-downloads:true,file-cache:parallel-downloads-per-file:100,file-cache:max-parallel-downloads:-1,file-cache:download-chunk-size-mb:50,file-cache:max-size-mb:-1"
+        - name: shared-memory
+          emptyDir:
+            medium: "Memory"
+            sizeLimit: 250Gi
+        initContainers:
+        - name: nccl-plugin-installer
+          image: us-docker.pkg.dev/gce-ai-infra/gpudirect-gib/nccl-plugin-gib-arm64:v1.0.7
+          imagePullPolicy: Always
+          command: ["/bin/sh", "-c"]
+          args:
+          - |
+            set -ex
+            /scripts/container_entry.sh install --install-nccl
+            cp -R /var/lib/gib/lib64/. /target/usr/local/gib/lib64
+            cp -R /var/lib/gib/. /target/usr/local/gib
+          volumeMounts:
+          - mountPath: /target/usr/local/gib
+            name: gib
+        containers:
+        - name: sglang-server
+          image: {{ .Values.workload.image | default "lmsysorg/sglang:kimi-k3" }}
+          imagePullPolicy: Always
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              nvidia.com/gpu: 4
+            limits:
+              nvidia.com/gpu: 4
+            claims:
+            - name: compute-domain-channel
+          env:
+          - name: LWS_WORKER_INDEX
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.labels['leaderworkerset.sigs.k8s.io/worker-index']
+          - name: LWS_LEADER_ADDRESS
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.annotations['leaderworkerset.sigs.k8s.io/leader-address']
+          - name: LWS_GROUP_SIZE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.annotations['leaderworkerset.sigs.k8s.io/group-size']
+          - name: NCCL_PLUGIN_PATH
+            value: /usr/local/gib/lib64
+          - name: LD_LIBRARY_PATH
+            value: /usr/local/gib/lib64:/usr/local/nvidia/lib64
+          - name: NCCL_INIT_SCRIPT
+            value: /usr/local/gib/scripts/set_nccl_env.sh
+          - name: NCCL_DEBUG
+            value: "INFO"
+          - name: NCCL_MNNVL_ENABLE
+            value: "1"
+          - name: NCCL_CUMEM_ENABLE
+            value: "1"
+          - name: NCCL_NET_GDR_LEVEL
+            value: "PIX"
+          - name: NCCL_NET_GDR_C2C
+            value: "1"
+          volumeMounts:
+          - mountPath: /usr/local/gib
+            name: gib
+          - mountPath: /gcs-cache
+            name: local-ssd
+          - mountPath: /data/model
+            name: gcs-model-volume
+          - mountPath: /dev/shm
+            name: shared-memory
+          command: ["/bin/bash", "-c"]
+          args:
+          - |
+            set -e
+            nvidia-smi
+            . /usr/local/gib/scripts/set_nccl_env.sh
+            pip install --break-system-packages hf_transfer fla-core google-cloud-storage || true
+
+            MY_IP=$(hostname -I | awk '{print $1}')
+            export SGLANG_HOST_IP="${MY_IP}"
+            export GLOO_SOCKET_IFNAME=eth0
+            export NCCL_SOCKET_IFNAME=eth0
+
+            LEADER_HOST="${LWS_LEADER_ADDRESS:-{{ .Release.Name }}-0.{{ .Release.Name }}}"
+            RANK="${LWS_WORKER_INDEX:-0}"
+            SIZE="${LWS_GROUP_SIZE:-{{ .Values.workload.nnodes | default 4 }}}"
+
+            echo "=== STARTING MULTI-HOST SGLANG SERVE ==="
+            echo "My IP: ${MY_IP}"
+            echo "Node Rank: ${RANK} / Total Nodes: ${SIZE}"
+            echo "Leader Address: ${LEADER_HOST}:20000"
+
+            python3 -m sglang.launch_server \
+              --trust-remote-code \
+              --model-path {{ .Values.workload.modelPath | default "gs://pirillo-sct-bucket/huggingface_model_cache/models--moonshotai--Kimi-K3/" }} \
+              --tp-size {{ .Values.workload.tpSize | default 16 }} \
+              --nnodes ${SIZE} \
+              --node-rank ${RANK} \
+              --dist-init-addr ${LEADER_HOST}:20000 \
+              --dcp-size {{ .Values.workload.dcpSize | default 16 }} \
+              --mem-fraction-static 0.85 \
+              --disaggregation-decode-extra-slots 16 \
+              --reasoning-parser kimi_k3 \
+              --tool-call-parser kimi_k3 \
+              --disaggregation-mode decode \
+              --disaggregation-transfer-backend nixl \
+              --mamba-full-memory-ratio 0.86 \
+              --host 0.0.0.0 \
+              --port 30100 2>&1 | tee /gcs-cache/sglang_server_${RANK}.log
+
+    workerTemplate:
+      metadata:
+        labels:
+          role: worker
+          app: {{ .Release.Name }}
+        annotations:
+          gke-gcsfuse/volumes: "true"
+          gke-gcsfuse/cpu-limit: "0"
+          gke-gcsfuse/memory-limit: "0"
+          gke-gcsfuse/ephemeral-storage-limit: "0"
+          gke-gcsfuse/file-cache-capacity: "500Gi"
+          gke-gcsfuse/cache-path: "/gcs-cache"
+          networking.gke.io/default-interface: "eth0"
+      spec:
+        hostNetwork: true
+        dnsPolicy: ClusterFirstWithHostNet
+        serviceAccountName: {{ .Values.workload.serviceAccountName | default "workload-identity-k8s-sa" }}
+        automountServiceAccountToken: true
+        subdomain: {{ .Release.Name }}
+        restartPolicy: Always
+        resourceClaims:
+        - name: compute-domain-channel
+          resourceClaimTemplateName: {{ .Release.Name }}-compute-domain-claim
+        tolerations:
+        - key: "kubernetes.io/arch"
+          operator: "Equal"
+          value: "arm64"
+          effect: "NoSchedule"
+        - key: "nvidia.com/gpu"
+          operator: "Exists"
+          effect: "NoSchedule"
+        volumes:
+        - name: gib
+          emptyDir: {}
+        - name: local-ssd
+          emptyDir: {}
+        - name: gcs-model-volume
+          csi:
+            driver: gcsfuse.csi.storage.gke.io
+            volumeAttributes:
+              bucketName: "{{ .Values.volumes.gcsfuse.bucketName | default "pirillo-sct-bucket" }}"
+              mountOptions: "implicit-dirs,file-cache:enable-parallel-downloads:true,file-cache:parallel-downloads-per-file:100,file-cache:max-parallel-downloads:-1,file-cache:download-chunk-size-mb:50,file-cache:max-size-mb:-1"
+        - name: shared-memory
+          emptyDir:
+            medium: "Memory"
+            sizeLimit: 250Gi
+        initContainers:
+        - name: nccl-plugin-installer
+          image: us-docker.pkg.dev/gce-ai-infra/gpudirect-gib/nccl-plugin-gib-arm64:v1.0.7
+          imagePullPolicy: Always
+          command: ["/bin/sh", "-c"]
+          args:
+          - |
+            set -ex
+            /scripts/container_entry.sh install --install-nccl
+            cp -R /var/lib/gib/lib64/. /target/usr/local/gib/lib64
+            cp -R /var/lib/gib/. /target/usr/local/gib
+          volumeMounts:
+          - mountPath: /target/usr/local/gib
+            name: gib
+        containers:
+        - name: sglang-server
+          image: {{ .Values.workload.image | default "lmsysorg/sglang:kimi-k3" }}
+          imagePullPolicy: Always
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              nvidia.com/gpu: 4
+            limits:
+              nvidia.com/gpu: 4
+            claims:
+            - name: compute-domain-channel
+          env:
+          - name: LWS_WORKER_INDEX
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.labels['leaderworkerset.sigs.k8s.io/worker-index']
+          - name: LWS_LEADER_ADDRESS
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.annotations['leaderworkerset.sigs.k8s.io/leader-address']
+          - name: LWS_GROUP_SIZE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.annotations['leaderworkerset.sigs.k8s.io/group-size']
+          - name: NCCL_PLUGIN_PATH
+            value: /usr/local/gib/lib64
+          - name: LD_LIBRARY_PATH
+            value: /usr/local/gib/lib64:/usr/local/nvidia/lib64
+          - name: NCCL_INIT_SCRIPT
+            value: /usr/local/gib/scripts/set_nccl_env.sh
+          - name: NCCL_DEBUG
+            value: "INFO"
+          - name: NCCL_MNNVL_ENABLE
+            value: "1"
+          - name: NCCL_CUMEM_ENABLE
+            value: "1"
+          - name: NCCL_NET_GDR_LEVEL
+            value: "PIX"
+          - name: NCCL_NET_GDR_C2C
+            value: "1"
+          volumeMounts:
+          - mountPath: /usr/local/gib
+            name: gib
+          - mountPath: /gcs-cache
+            name: local-ssd
+          - mountPath: /data/model
+            name: gcs-model-volume
+          - mountPath: /dev/shm
+            name: shared-memory
+          command: ["/bin/bash", "-c"]
+          args:
+          - |
+            set -e
+            nvidia-smi
+            . /usr/local/gib/scripts/set_nccl_env.sh
+            pip install --break-system-packages hf_transfer fla-core google-cloud-storage || true
+
+            MY_IP=$(hostname -I | awk '{print $1}')
+            export SGLANG_HOST_IP="${MY_IP}"
+            export GLOO_SOCKET_IFNAME=eth0
+            export NCCL_SOCKET_IFNAME=eth0
+
+            LEADER_HOST="${LWS_LEADER_ADDRESS:-{{ .Release.Name }}-0.{{ .Release.Name }}}"
+            RANK="${LWS_WORKER_INDEX:-0}"
+            SIZE="${LWS_GROUP_SIZE:-{{ .Values.workload.nnodes | default 4 }}}"
+
+            echo "=== STARTING MULTI-HOST SGLANG SERVE ==="
+            echo "My IP: ${MY_IP}"
+            echo "Node Rank: ${RANK} / Total Nodes: ${SIZE}"
+            echo "Leader Address: ${LEADER_HOST}:20000"
+
+            python3 -m sglang.launch_server \
+              --trust-remote-code \
+              --model-path {{ .Values.workload.modelPath | default "gs://pirillo-sct-bucket/huggingface_model_cache/models--moonshotai--Kimi-K3/" }} \
+              --tp-size {{ .Values.workload.tpSize | default 16 }} \
+              --nnodes ${SIZE} \
+              --node-rank ${RANK} \
+              --dist-init-addr ${LEADER_HOST}:20000 \
+              --dcp-size {{ .Values.workload.dcpSize | default 16 }} \
+              --mem-fraction-static 0.85 \
+              --disaggregation-decode-extra-slots 16 \
+              --reasoning-parser kimi_k3 \
+              --tool-call-parser kimi_k3 \
+              --disaggregation-mode decode \
+              --disaggregation-transfer-backend nixl \
+              --mamba-full-memory-ratio 0.86 \
+              --host 0.0.0.0 \
+              --port 30100 2>&1 | tee /gcs-cache/sglang_server_${RANK}.log

--- a/src/helm-charts/a4x/inference-templates/lws-deployment/templates/lws-launcher.yaml
+++ b/src/helm-charts/a4x/inference-templates/lws-deployment/templates/lws-launcher.yaml
@@ -72,7 +72,7 @@ spec:
             name: gib
         containers:
         - name: sglang-server
-          image: {{ .Values.workload.image | default "lmsysorg/sglang:kimi-k3" }}
+          image: {{ .Values.workload.image }}
           imagePullPolicy: Always
           securityContext:
             privileged: true
@@ -127,7 +127,9 @@ spec:
             set -e
             nvidia-smi
             . /usr/local/gib/scripts/set_nccl_env.sh
-            pip install --break-system-packages hf_transfer fla-core || true
+            {{- if .Values.workload.extraPipPackages }}
+            pip install --break-system-packages {{ .Values.workload.extraPipPackages }} || true
+            {{- end }}
 
             MY_IP=$(hostname -I | awk '{print $1}')
             export SGLANG_HOST_IP="${MY_IP}"
@@ -144,16 +146,27 @@ spec:
             echo "Leader Address: ${LEADER_HOST}:20000"
 
             python3 -m sglang.launch_server \
-              --trust-remote-code \
               --model-path {{ .Values.workload.modelPath | default (printf "/data/model/%s" .Values.workload.model) }} \
               --tp-size {{ .Values.workload.tpSize | default 16 }} \
               --nnodes ${SIZE} \
               --node-rank ${RANK} \
               --dist-init-addr ${LEADER_HOST}:20000 \
-              --mem-fraction-static 0.85 \
-              --reasoning-parser kimi_k3 \
-              --tool-call-parser kimi_k3 \
-              --mamba-full-memory-ratio 0.86 \
+              --mem-fraction-static {{ .Values.workload.memFractionStatic | default 0.85 }} \
+              {{- if .Values.workload.trustRemoteCode }}
+              --trust-remote-code \
+              {{- end }}
+              {{- if .Values.workload.reasoningParser }}
+              --reasoning-parser {{ .Values.workload.reasoningParser }} \
+              {{- end }}
+              {{- if .Values.workload.toolCallParser }}
+              --tool-call-parser {{ .Values.workload.toolCallParser }} \
+              {{- end }}
+              {{- if .Values.workload.mambaFullMemoryRatio }}
+              --mamba-full-memory-ratio {{ .Values.workload.mambaFullMemoryRatio }} \
+              {{- end }}
+              {{- if .Values.workload.extraArgs }}
+              {{ .Values.workload.extraArgs }} \
+              {{- end }}
               --host 0.0.0.0 \
               --port 30100 2>&1 | tee /gcs-cache/sglang_server_${RANK}.log
 
@@ -219,7 +232,7 @@ spec:
             name: gib
         containers:
         - name: sglang-server
-          image: {{ .Values.workload.image | default "lmsysorg/sglang:kimi-k3" }}
+          image: {{ .Values.workload.image }}
           imagePullPolicy: Always
           securityContext:
             privileged: true
@@ -274,7 +287,9 @@ spec:
             set -e
             nvidia-smi
             . /usr/local/gib/scripts/set_nccl_env.sh
-            pip install --break-system-packages hf_transfer fla-core || true
+            {{- if .Values.workload.extraPipPackages }}
+            pip install --break-system-packages {{ .Values.workload.extraPipPackages }} || true
+            {{- end }}
 
             MY_IP=$(hostname -I | awk '{print $1}')
             export SGLANG_HOST_IP="${MY_IP}"
@@ -291,15 +306,26 @@ spec:
             echo "Leader Address: ${LEADER_HOST}:20000"
 
             python3 -m sglang.launch_server \
-              --trust-remote-code \
               --model-path {{ .Values.workload.modelPath | default (printf "/data/model/%s" .Values.workload.model) }} \
               --tp-size {{ .Values.workload.tpSize | default 16 }} \
               --nnodes ${SIZE} \
               --node-rank ${RANK} \
               --dist-init-addr ${LEADER_HOST}:20000 \
-              --mem-fraction-static 0.85 \
-              --reasoning-parser kimi_k3 \
-              --tool-call-parser kimi_k3 \
-              --mamba-full-memory-ratio 0.86 \
+              --mem-fraction-static {{ .Values.workload.memFractionStatic | default 0.85 }} \
+              {{- if .Values.workload.trustRemoteCode }}
+              --trust-remote-code \
+              {{- end }}
+              {{- if .Values.workload.reasoningParser }}
+              --reasoning-parser {{ .Values.workload.reasoningParser }} \
+              {{- end }}
+              {{- if .Values.workload.toolCallParser }}
+              --tool-call-parser {{ .Values.workload.toolCallParser }} \
+              {{- end }}
+              {{- if .Values.workload.mambaFullMemoryRatio }}
+              --mamba-full-memory-ratio {{ .Values.workload.mambaFullMemoryRatio }} \
+              {{- end }}
+              {{- if .Values.workload.extraArgs }}
+              {{ .Values.workload.extraArgs }} \
+              {{- end }}
               --host 0.0.0.0 \
               --port 30100 2>&1 | tee /gcs-cache/sglang_server_${RANK}.log

--- a/src/helm-charts/a4x/inference-templates/lws-deployment/templates/lws-svc.yaml
+++ b/src/helm-charts/a4x/inference-templates/lws-deployment/templates/lws-svc.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-svc
+  namespace: default
+  labels:
+    app: {{ .Release.Name }}
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 8000
+      targetPort: 8000
+      protocol: TCP
+  selector:
+    leaderworkerset.sigs.k8s.io/name: {{ .Release.Name }}
+    leaderworkerset.sigs.k8s.io/worker-index: "0"

--- a/src/helm-charts/a4x/inference-templates/lws-deployment/templates/lws-svc.yaml
+++ b/src/helm-charts/a4x/inference-templates/lws-deployment/templates/lws-svc.yaml
@@ -2,15 +2,15 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Release.Name }}-svc
-  namespace: default
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ .Release.Name }}
 spec:
   type: ClusterIP
   ports:
     - name: http
-      port: 8000
-      targetPort: 8000
+      port: 30100
+      targetPort: 30100
       protocol: TCP
   selector:
     leaderworkerset.sigs.k8s.io/name: {{ .Release.Name }}


### PR DESCRIPTION
Adds an initial recipe for running Kimi-K3 on A4X / GB200 machines based on the recently release sgLang cookbook for K3. https://docs.sglang.io/cookbook/autoregressive/Moonshotai/Kimi-K3